### PR TITLE
Use multistage build for image

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,7 @@
 FROM lisa/musl-cross:1.1.19
-MAINTAINER Andrew Dunham <andrew@du.nham.ca>
+MAINTAINER Lisa Seelye <lisa@thedoh.com>
+# Upstream maintainer:
+#MAINTAINER Andrew Dunham <andrew@du.nham.ca>
 
 RUN apt-get update && apt-get install -y zip
 
@@ -7,4 +9,16 @@ RUN apt-get update && apt-get install -y zip
 ADD . /build/
 
 # This builds the program and copies it to /output
-CMD /build/build.sh
+RUN /build/build.sh
+
+###
+FROM scratch
+MAINTAINER Lisa Seelye <lisa@thedoh.com>
+WORKDIR /
+COPY --from=0 /output/python* /
+ENV \
+  PYTHONHOME=/python2.7.zip \
+  PYTHONPATH=/python2.7.zip
+
+ENTRYPOINT [ "/python", "-s", "-S" ]
+

--- a/python/build.sh
+++ b/python/build.sh
@@ -150,21 +150,17 @@ function doit() {
     build_openssl
     build_python
 
-    # Copy to output
-    if [ -d /output ]
-    then
-        OUT_DIR=/output/`uname | tr 'A-Z' 'a-z'`/`uname -m`
-        mkdir -p $OUT_DIR
-        cp /build/Python-${PYTHON_BASE_VERSION}${PYTHON_RC}/{python,python2.7.zip} $OUT_DIR/
-        echo "** Finished **"
-    else
-        echo "** /output does not exist **"
-    fi
-#    while true
-#    do
-#      sleep 3600
-#    done
+
+		mkdir -p /output
+		cp /build/Python-${PYTHON_BASE_VERSION}${PYTHON_RC}/{python,python2.7.zip} /output
+
 
 }
 
 doit
+
+echo "Output:"
+ls -l /output
+echo "Done."
+
+


### PR DESCRIPTION
With this there's no need to have a separate Dockerfile that takes the
files (in `../binaries/linux/.....`) that makes the base Python image.